### PR TITLE
Update lib/OTRS/OPR/DB/Helper/Package.pm

### DIFF
--- a/lib/OTRS/OPR/DB/Helper/Package.pm
+++ b/lib/OTRS/OPR/DB/Helper/Package.pm
@@ -83,7 +83,7 @@ sub page {
         {
             page      => $page,
             rows      => $rows,
-            order_by  => 'package_id',
+            order_by  => 'upload_time DESC',
             group_by  => [ 'opr_package_names.package_name' ],
             join      => 'opr_package_names',
             '+select' => [ 'opr_package_names.package_name' ],


### PR DESCRIPTION
http://opar.perl-services.de/bin/index.cgi/rss/recent is always showing the oldest package first. I guess this will change it, but I was not able to test it. :-/

Please verify.
